### PR TITLE
Add: Support for registered SVG icons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import { MatCarousel, MatCarouselComponent } from '@ngmodule/material-carousel';
 | `useKeyboard`    | `boolean`      | Enable keyboard navigation.               | `true`            |
 | `useMouseWheel`  | `boolean`      | Enable navigation through mouse wheeling. | `false`           |
 | `orientation`    | `Orientation`  | Orientation of the sliding panel.         | `'ltr'`           |
-
+| `svgIconDefs`    | `MatCarouselSvgIconDefs`  | Override default carousel icons with registered SVG icons.         |           |
 ### `MatCarouselSlideComponent`
 ```typescript
 import { MatCarouselSlide, MatCarouselSlideComponent } from '@ngmodule/material-carousel';

--- a/projects/carousel/src/lib/carousel.component.html
+++ b/projects/carousel/src/lib/carousel.component.html
@@ -33,7 +33,10 @@
     [disabled]="!loop && currentIndex == 0"
     (click)="previous()"
   >
-    <mat-icon>arrow_back</mat-icon>
+  <ng-container [ngSwitch]="svgIconDefs?.arrow_back?.length > 0">
+    <mat-icon *ngSwitchDefault>arrow_back</mat-icon>
+    <mat-icon *ngSwitchCase="true" svgIcon="{{svgIconDefs.arrow_back}}"></mat-icon>
+  </ng-container>
   </button>
   <button
     *ngIf="!hideArrows"
@@ -43,7 +46,10 @@
     [disabled]="!loop && currentIndex == slidesList.length - 1"
     (click)="next()"
   >
-    <mat-icon>arrow_forward</mat-icon>
+    <ng-container [ngSwitch]="svgIconDefs?.arrow_forward?.length > 0">
+      <mat-icon *ngSwitchDefault>arrow_forward</mat-icon>
+      <mat-icon *ngSwitchCase="true" svgIcon="{{svgIconDefs.arrow_forward}}"></mat-icon>
+    </ng-container>
   </button>
 
   <div

--- a/projects/carousel/src/lib/carousel.component.ts
+++ b/projects/carousel/src/lib/carousel.component.ts
@@ -20,7 +20,7 @@ import { ThemePalette } from '@angular/material';
 import { interval, BehaviorSubject, Observable, Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
-import { MatCarousel, Orientation } from './carousel';
+import { MatCarousel, Orientation, MatCarouselSvgIconDefs } from './carousel';
 import { MatCarouselSlideComponent } from './carousel-slide/carousel-slide.component';
 
 enum Direction {
@@ -37,6 +37,7 @@ enum Direction {
 export class MatCarouselComponent
   implements AfterContentInit, AfterViewInit, MatCarousel, OnDestroy {
   @Input() public timings = '250ms ease-in';
+  @Input() public svgIconDefs:MatCarouselSvgIconDefs;
 
   @Input()
   public set autoplay(value: boolean) {

--- a/projects/carousel/src/lib/carousel.ts
+++ b/projects/carousel/src/lib/carousel.ts
@@ -2,6 +2,11 @@ import { ThemePalette } from '@angular/material';
 
 export type Orientation = 'ltr' | 'rtl';
 
+export interface MatCarouselSvgIconDefs{
+  arrow_back: string,
+  arrow_forward: string
+}
+
 export interface MatCarousel {
   // Animations.
   timings: string;
@@ -16,6 +21,7 @@ export interface MatCarousel {
   maxWidth: string;
   proportion: number;
   slides: number;
+  svgIconDefs: MatCarouselSvgIconDefs;
   // Accessibility.
   useKeyboard: boolean;
   useMouseWheel: boolean;


### PR DESCRIPTION
Adds 'svgIconDefs' input parameter to 'MatCarouselComponent'. This enables the default carousel icons to be overridden with SVG icon names registered via 'MatIconRegistry' injectable service.

See https://material.angular.io/components/icon/overview#registering-icons