### PR TITLE
Image Url Sanitization

### DIFF
--- a/projects/carousel/src/lib/carousel-slide/carousel-slide.component.ts
+++ b/projects/carousel/src/lib/carousel-slide/carousel-slide.component.ts
@@ -6,6 +6,7 @@ import {
   TemplateRef,
   ViewChild
 } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 
 import { MatCarouselSlide } from './carousel-slide';
 
@@ -22,10 +23,13 @@ export class MatCarouselSlideComponent
   @Input() public disabled = false; // implements ListKeyManagerOption
 
   @ViewChild(TemplateRef) public templateRef: TemplateRef<any>;
+    
+  constructor(public sanitizer: DomSanitizer) {
+  }
 
   public ngOnInit(): void {
     if (this.image) {
-      this.image = `url("${this.image}")`;
+      this.image = this.sanitizer.bypassSecurityTrustStyle(`url("${this.image}")`);
     }
   }
 }

--- a/projects/carousel/src/lib/carousel-slide/carousel-slide.component.ts
+++ b/projects/carousel/src/lib/carousel-slide/carousel-slide.component.ts
@@ -6,9 +6,9 @@ import {
   TemplateRef,
   ViewChild
 } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
+import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
 
-import { MatCarouselSlide, SafeStyle } from './carousel-slide';
+import { MatCarouselSlide } from './carousel-slide';
 
 @Component({
   selector: 'mat-carousel-slide',

--- a/projects/carousel/src/lib/carousel-slide/carousel-slide.component.ts
+++ b/projects/carousel/src/lib/carousel-slide/carousel-slide.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
-import { MatCarouselSlide } from './carousel-slide';
+import { MatCarouselSlide, SafeStyle } from './carousel-slide';
 
 @Component({
   selector: 'mat-carousel-slide',
@@ -17,7 +17,7 @@ import { MatCarouselSlide } from './carousel-slide';
 })
 export class MatCarouselSlideComponent
   implements ListKeyManagerOption, MatCarouselSlide, OnInit {
-  @Input() public image: string;
+  @Input() public image: SafeStyle;
   @Input() public overlayColor = '#00000040';
   @Input() public hideOverlay = false;
   @Input() public disabled = false; // implements ListKeyManagerOption

--- a/projects/carousel/src/lib/carousel-slide/carousel-slide.ts
+++ b/projects/carousel/src/lib/carousel-slide/carousel-slide.ts
@@ -1,5 +1,5 @@
 export interface MatCarouselSlide {
-  image: string;
+  image: SafeStyle;
   overlayColor: string;
   hideOverlay: boolean;
   disabled: boolean;

--- a/projects/carousel/src/lib/carousel-slide/carousel-slide.ts
+++ b/projects/carousel/src/lib/carousel-slide/carousel-slide.ts
@@ -1,3 +1,5 @@
+import { SafeStyle } from '@angular/platform-browser';
+
 export interface MatCarouselSlide {
   image: SafeStyle;
   overlayColor: string;


### PR DESCRIPTION
When setting an external url as `[image]` property in `mat-carousel-slide`, angular gives `WARNING: sanitizing unsafe style value` and does not load the image.

I found that setting `[style.background-image]` as `SafeStyle` instead of `string`, parsing it by using `sanitizer.bypassSecurityTrustStyle` solves the problem.

https://angular.io/guide/security#xss