### PR TITLE
Add button type to control buttons

### DIFF
--- a/projects/carousel/src/lib/carousel.component.html
+++ b/projects/carousel/src/lib/carousel.component.html
@@ -28,6 +28,7 @@
   <button
     *ngIf="!hideArrows"
     mat-icon-button
+    type="button"
     tabindex="-1"
     [color]="color"
     [disabled]="!loop && currentIndex == 0"
@@ -44,6 +45,7 @@
   <button
     *ngIf="!hideArrows"
     mat-icon-button
+    type="button"
     tabindex="-1"
     [color]="color"
     [disabled]="!loop && currentIndex == slidesList.length - 1"
@@ -66,6 +68,7 @@
   >
     <button
       *ngFor="let slide of slidesList; let i = index"
+      type="button"
       tabindex="-1"
       mat-mini-fab
       [color]="color"


### PR DESCRIPTION
When the carousel is used inside a `<form (ngSubmit)="...">`, its controls trigger form submission. Adding `type="button"` to the buttons fixes this issue (their default is `type="submit"`).