### PR TITLE
(refactor) Support for Angular v9.

### DIFF
--- a/projects/carousel/src/lib/carousel.component.ts
+++ b/projects/carousel/src/lib/carousel.component.ts
@@ -18,7 +18,7 @@ import {
   Renderer2,
   ViewChild
 } from '@angular/core';
-import { ThemePalette } from '@angular/material';
+import { ThemePalette } from '@angular/material/core';
 import { interval, BehaviorSubject, Observable, Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 

--- a/projects/carousel/src/lib/carousel.ts
+++ b/projects/carousel/src/lib/carousel.ts
@@ -1,4 +1,4 @@
-import { ThemePalette } from '@angular/material';
+import { ThemePalette } from '@angular/material/core';
 
 export interface MatCarousel {
   // Animations.

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { Component, ElementRef, QueryList, ViewChildren } from '@angular/core';
-import { ThemePalette } from '@angular/material';
+import { ThemePalette } from '@angular/material/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import {
   MatCarouselSlideComponent,


### PR DESCRIPTION
Properly import the ThemePalette from the core of Ng Material.

I was testing the latest Angular release v9.0.0-rc.0 and I decided to test this library with it.
At first it wasn't building because of the error:

> '@angular/material/index.d.ts' is not a module

which is caused by a breaking change introduced by v9.0.0-next.0 with the message:

> Components can no longer be imported through "@angular/material". Use the individual secondary entry-points, such as @angular/material/button.

I made some tests and this PR is not likely to introduce any backwards conflict with the currently supported version.